### PR TITLE
FP-424: Remove auto-merge

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -35,7 +35,7 @@ mergeable:
             message: Change is very large, Should be under 500 lines of additions and deletions.
 
     pass:
-      - do: merge
-        merge_method: 'squash'
+      # - do: merge
+        # merge_method: 'squash'
       - do: checks
         status: 'success'


### PR DESCRIPTION
This was done a while ago and hasn't been used much. I commented out the auto-merge once all checks pass. Seems a little dangerous at the moment.